### PR TITLE
fix(grammars): update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 # gopanel
-
-go panel , manager caddy and  guard go web server
+A control panel that is written in Golang and is able to manage Caddy and Guard Go web server.


### PR DESCRIPTION
- manager 是名詞 (noun.)，不應該作動詞 (verb.) 用。
  - 改成 **manage**
- 一些語法通順的修正。